### PR TITLE
Fix potential typo

### DIFF
--- a/docs/sections/description-en.html
+++ b/docs/sections/description-en.html
@@ -94,7 +94,7 @@ Some examples of orthology databases that provide HOGs:
 
 </p>
 <h3 id="structCluster" class="list">Non-hierarchical cluster of homologous sequences</h3>
-<p>Several orhotology databases solely generate non-hierarchical
+<p>Several orthology databases solely generate non-hierarchical
 <a href="#HomologsCluster" title="http://purl.org/net/orth#HomologsCluster">clusters of homologous sequences</a> or besides HOGs, they provide 
 non-hierarchical clusters (i.e.: groups). Frequently the number of pairwise homology relations derived from the non-hierarchical 
 <a href="#HomologsCluster" title="http://purl.org/net/orth#HomologsCluster">clusters of homologous sequences</a>


### PR DESCRIPTION
I think "orhotology" was supposed to be "orthology" but maybe it's a new orthology term I haven't heard of